### PR TITLE
Make paneldf! output opt-in via verbose keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ using PanelDataTools,DataFrames,Dates
 df = DataFrame(id=fill(1,4),
     t=[Date(2000,1,1),Date(2000,1,2),Date(2000,2,1),Date(2001,1,1)],
     a=[0,1,1,1])
-paneldf!(df,:id,:t)
+paneldf!(df,:id,:t; verbose=true) # verbose=true prints the inferred panel/time/delta
 
 panel variable: id
  time variable: t

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,8 +1,10 @@
 ## Metadata
 """
-    paneldf!(df,PID::Symbol,TID:Symbol)
+    paneldf!(df,PID::Symbol,TID::Symbol; verbose=false)
 
 Attaches `:PID` and `:TID` to `df` so that one doesn't have to pass those all the times.
+
+Pass `verbose=true` to print the inferred panel variable, time variable, and delta.
 
 # Examples
 ```jldoctest
@@ -19,7 +21,7 @@ lag!(df,:x) # No need to specify panel (:id) and time (:t) columns
    4 │     2      2      0        1
 ```
 """
-function paneldf!(df,PID::Symbol,TID::Symbol)
+function paneldf!(df,PID::Symbol,TID::Symbol; verbose=false)
     @assert (String(PID) in names(df)) == true String(PID)*" (panel variable) does not exist in df"
     @assert (String(TID) in names(df)) == true String(TID)*" (time variable) does not exist in df"
 
@@ -27,9 +29,12 @@ function paneldf!(df,PID::Symbol,TID::Symbol)
     metadata!(df, "TID", TID, style=:note)
     metadata!(df, "Delta", oneunit(df[1,TID]-df[1, TID]),style=:note)
 
-    println("panel variable: "*String(metadata(df,"PID")))
-    println(" time variable: "*String(metadata(df,"TID")))
-    println("         delta: "*string(metadata(df,"Delta")))
+    if verbose
+        println("panel variable: "*String(metadata(df,"PID")))
+        println(" time variable: "*String(metadata(df,"TID")))
+        println("         delta: "*string(metadata(df,"Delta")))
+    end
+    return nothing
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -388,6 +388,29 @@ end
         @test_broken isequal(dfb.D1a,df.D1a)
     end
 
+    @testset "Issue #34 - paneldf! output only when asked" begin
+        # Helper: capture everything written to stdout while running `f`.
+        capture_stdout(f) = mktemp() do path, io
+            redirect_stdout(f, io)
+            flush(io)
+            read(path, String)
+        end
+
+        # verbose=true prints the panel summary
+        out = capture_stdout() do
+            paneldf!(test_df_simple1(), :id, :t; verbose=true)
+        end
+        @test occursin("panel variable", out)
+        @test occursin("time variable", out)
+        @test occursin("delta", out)
+
+        # Default (verbose=false) prints nothing
+        out = capture_stdout() do
+            paneldf!(test_df_simple1(), :id, :t)
+        end
+        @test isempty(out)
+    end
+
 end
 
 ## Testing dates


### PR DESCRIPTION
paneldf! previously always printed the inferred panel variable, time variable, and delta. Gate those prints behind a `verbose=false` keyword so paneldf! is silent by default and only reports when asked.

Add tests that capture stdout for both verbose=true (prints the summary) and the default (prints nothing), document the keyword in the docstring, and update the README example to pass verbose=true.

Closes #34