### PR TITLE
Let paneldf! set a custom default time gap (delta)

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,8 +1,12 @@
 ## Metadata
 """
-    paneldf!(df,PID::Symbol,TID::Symbol; verbose=false)
+    paneldf!(df,PID::Symbol,TID::Symbol; delta=oneunit(df[1,TID]-df[1,TID]), verbose=false)
 
 Attaches `:PID` and `:TID` to `df` so that one doesn't have to pass those all the times.
+
+`delta` sets the default time gap used by `lag!`, `diff!`, etc. when no gap is
+given; it defaults to one unit of the time variable but can be overridden, e.g.
+`paneldf!(df, :id, :t; delta=Year(2))`.
 
 Pass `verbose=true` to print the inferred panel variable, time variable, and delta.
 
@@ -21,13 +25,17 @@ lag!(df,:x) # No need to specify panel (:id) and time (:t) columns
    4 │     2      2      0        1
 ```
 """
-function paneldf!(df,PID::Symbol,TID::Symbol; verbose=false)
+function paneldf!(df,PID::Symbol,TID::Symbol; delta=nothing, verbose=false)
     @assert (String(PID) in names(df)) == true String(PID)*" (panel variable) does not exist in df"
     @assert (String(TID) in names(df)) == true String(TID)*" (time variable) does not exist in df"
+    # Resolve the default here (not in the signature): it reads df[1,TID], which
+    # must only happen after TID is confirmed to exist.
+    delta = isnothing(delta) ? oneunit(df[1,TID]-df[1, TID]) : delta
+    @assert delta > zero(delta) "delta (default time gap) must be positive"
 
     metadata!(df, "PID", PID, style=:note)
     metadata!(df, "TID", TID, style=:note)
-    metadata!(df, "Delta", oneunit(df[1,TID]-df[1, TID]),style=:note)
+    metadata!(df, "Delta", delta, style=:note)
 
     if verbose
         println("panel variable: "*String(metadata(df,"PID")))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -411,6 +411,30 @@ end
         @test isempty(out)
     end
 
+    @testset "Issue #24 - paneldf! custom default time gap (delta)" begin
+        # Default delta is the unit step
+        df = test_df_simple1()
+        paneldf!(df,:id,:t)
+        @test metadata(df,"Delta") == 1
+
+        # A custom integer delta is stored and used as the default gap by lag!
+        df = test_df_simple1_long()
+        paneldf!(df,:id,:t; delta=2)
+        @test metadata(df,"Delta") == 2
+        lag!(df,:a) # uses Delta=2 by default -> column L2a
+        dfb = test_df_simple1_long()
+        lag!(dfb,:id,:t,:a,2) # explicit 2-period lag
+        @test isequal(df.L2a, dfb.L2a)
+
+        # A custom delta works with Date-typed time too
+        df = test_df_date()
+        paneldf!(df,:id,:t; delta=Year(1))
+        @test metadata(df,"Delta") == Year(1)
+
+        # delta must be positive
+        @test_throws AssertionError paneldf!(test_df_simple1(),:id,:t; delta=0)
+    end
+
 end
 
 ## Testing dates


### PR DESCRIPTION
paneldf! always inferred the default gap as one unit of the time variable. Add a `delta` keyword so it can be overridden, e.g. `paneldf!(df, :id, :t; delta=Year(2))`, with a positivity assertion. This delta is what lag!/diff!/etc. read from metadata when no gap is passed.

Add tests for the default, a custom integer delta (and that lag! uses it), a Date-typed delta, and the positivity check; document the keyword in the docstring.

Closes #24