### PR TITLE
Release v0.4.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PanelDataTools"
 uuid = "f8e8dcbf-c8af-4c89-b3d0-30e7f728b8cf"
 authors = ["Eirik Eylands Brandsaas"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"


### PR DESCRIPTION
New features:
- checkpanel + isbalanced/hasgaps/hasduplicates: report panel structure (balanced, time gaps, duplicate (id,t) pairs) (#21)
- paneldf!: `delta` keyword to set a custom default time gap (#24)
- paneldf!: output is now opt-in via `verbose` (silent by default) (#34)

Fixes:
- tsfill: default `n` no longer errors (referenced an undefined name)

Maintenance:
- Corrected [compat]: DataFrames = "1.4", julia = "1.6" (match the metadata API actually used); removed Test from [deps]; stopped tracking Manifest.toml; CI tests the 1.6 floor, lts, and latest.

Note:
- Heavily co-authored by Claude, which finally made me bother to do these tedious updates.